### PR TITLE
Update for 2.9.7

### DIFF
--- a/ckan-setup/organogram.js
+++ b/ckan-setup/organogram.js
@@ -22,7 +22,7 @@ module.exports = async page => {
             document.getElementById('field-notes').value = organogramData.name;
 
             const schemaDropdown = document.getElementById('field-schema-vocabulary');
-            schemaDropdown.value = [...schemaDropdown.options].find(opt => opt.text.indexOf('Organisation structure') !== -1).value;
+            schemaDropdown.value = [...schemaDropdown.options].find(opt => opt.text.indexOf('Organisation structure including senior roles') !== -1).value;
         }, organogramData);
 
         await Promise.all([
@@ -30,29 +30,15 @@ module.exports = async page => {
             page.waitForNavigation()
         ]);
 
-        console.log('Adding resource without a source...');
-
-        await page.evaluate(() => {
-            document.getElementById('field-name').value = 'No source';
-        });
-
-        await Promise.all([
-            page.click('button[value="again"]'),
-            page.waitForNavigation()
-        ]);
-
         console.log('Adding resource with a source...');
 
         await waitForOrganogramJS(page);
 
-        await page.evaluate(() => {
-            document.getElementById('field-name').value = 'Source specified';
-            document.getElementById('field-image-url').value = 'https://ckan-static-mock-harvest-source.cloudapps.digital/mock-third-party/example-dataset-1/all-categories-summary.csv';
-        });
-
-        await page.click('.select2-choice');
-        await page.keyboard.type('csv');
-        await page.keyboard.press('Enter');
+        console.log('Uploading organogram xls file...');
+        // download latest sample organogram xls here - https://github.com/alphagov/ckanext-datagovuk/blob/main/tests/data/sample-valid.xls
+        const fileInput = await page.$('input[type=file]');
+        const filePath = "./ckan-setup/sample-valid.xls";
+        await fileInput.uploadFile(filePath);
 
         await Promise.all([
             page.click('button[value="go-metadata"]'),

--- a/configs/ckan-config.js
+++ b/configs/ckan-config.js
@@ -17,7 +17,7 @@ module.exports = id => ({
         "height": 768
         }
     ],
-    "misMatchThreshold": 0,
+    "misMatchThreshold": 15,
     "requireSameDimensions": false,
     "onBeforeScript": "onBefore.js",
     "onReadyScript": "onReady.js",
@@ -32,8 +32,7 @@ module.exports = id => ({
         { "label": "Dataset - add new resource", "url": `${process.env.DOMAIN}/dataset/new_resource/example-dataset-number-one`, "select2": true },
         { "label": "Dataset - view resource", "url": `${process.env.DOMAIN}/dataset/example-dataset-number-one/resource/${process.env.STANDARD_RESOURCE}`, "hideSelectors": ["table.table td:nth-child(2)"], "tableRows": true, "tableShowMore": true},
         { "label": "Dataset - edit resource", "url": `${process.env.DOMAIN}/dataset/example-dataset-number-one/resource_edit/${process.env.STANDARD_RESOURCE}`, "select2": true },
-        { "label": "Dataset - edit organogram resource: no source", "url": `${process.env.DOMAIN}/dataset/organogram-test/resource_edit/${process.env.ORGANOGRAM_RESOURCE_NO_SOURCE}`, "uploadField": true, "select2": true },
-        { "label": "Dataset - edit organogram resource: source specified", "url": `${process.env.DOMAIN}/dataset/organogram-test/resource_edit/${process.env.ORGANOGRAM_RESOURCE_SOURCE_SPECIFIED}`, "uploadField": true, "select2": true },
+        { "label": "Dataset - edit organogram resource: source specified", "url": `${process.env.DOMAIN}/dataset/organogram-test/resource_edit/${process.env.ORGANOGRAM_RESOURCE_SOURCE_SPECIFIED}`, "uploadField": true, "select2": false },
         { "label": "Publisher - default", "url": `${process.env.DOMAIN}/${id === "ckan-2.9" ? "organization" : "publisher"}` },
         { "label": "Publisher - add new", "url": `${process.env.DOMAIN}/${id === "ckan-2.9" ? "organization" : "publisher"}/new`, "slugPreview": true, "textarea": true },
         { "label": "Publisher - add new: form errors", "url": `${process.env.DOMAIN}/${id === "ckan-2.9" ? "organization" : "publisher"}/new`, "submitForm": true, "textarea": true },
@@ -72,6 +71,7 @@ module.exports = id => ({
     "report": [],
     "engine": "puppeteer",
     "engineOptions": {
+        // "headless": false,
         "args": ["--no-sandbox"],
     },
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "backstopjs": "^5.0.1",
     "dotenv": "^8.2.0",
-    "puppeteer": "^3.3.0"
+    "puppeteer": "^18.2.1"
   }
 }


### PR DESCRIPTION
## What 

Updated to work with CKAN 2.9.7, also updated the test so that it actually uses an organogram template file for testing against and updated the puppeteer version needed to run it.

## Reference 

https://trello.com/c/uWgUDRoc/1103-fix-ckan-visual-regression-tests-to-run-against-297